### PR TITLE
chore: fix numpy binary incompatibility issue and add QWEN agent package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ vertexai==1.49.0
 pydantic==2.7.1
 pydantic-settings==2.0.2
 pydantic_core==2.18.2
+numpy==1.24.0
+qwen_agent==0.0.10


### PR DESCRIPTION
안녕하세요, 카카오IF에서 좋은 오픈소스 공개와 발표 감사드립니다.
오픈소스를 사용해보다가 pandas와 numpy에서 아래와 같은 에러가 발생하여 패키지 버전을 수정하였습니다.

```
Traceback (most recent call last):
  File "/data/public/FunctionChat-Bench/evaluate.py", line 7, in <module>
    from src import utils
  File "/data/public/FunctionChat-Bench/src/utils.py", line 3, in <module>
    import pandas as pd
  File "/usr/local/lib/python3.10/dist-packages/pandas/__init__.py", line 22, in <module>
    from pandas.compat import is_numpy_dev as _is_numpy_dev  # pyright: ignore # noqa:F401
  File "/usr/local/lib/python3.10/dist-packages/pandas/compat/__init__.py", line 25, in <module>
    from pandas.compat.numpy import (
  File "/usr/local/lib/python3.10/dist-packages/pandas/compat/numpy/__init__.py", line 4, in <module>
    from pandas.util.version import Version
  File "/usr/local/lib/python3.10/dist-packages/pandas/util/__init__.py", line 2, in <module>
    from pandas.util._decorators import (  # noqa:F401
  File "/usr/local/lib/python3.10/dist-packages/pandas/util/_decorators.py", line 14, in <module>
    from pandas._libs.properties import cache_readonly
  File "/usr/local/lib/python3.10/dist-packages/pandas/_libs/__init__.py", line 13, in <module>
    from pandas._libs.interval import Interval
  File "pandas/_libs/interval.pyx", line 1, in init pandas._libs.interval
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```